### PR TITLE
Enhance 404 page

### DIFF
--- a/src/pages/NoPageFound.jsx
+++ b/src/pages/NoPageFound.jsx
@@ -25,7 +25,7 @@ const NoPageFound = () => {
         }
       })
       .catch((error) => console.error(error));
-  }, [photoUrl]);
+  }, []);
 
   const isPhotoFound = photoUrl !== null && photoUrl !== undefined;
 

--- a/src/pages/NoPageFound.jsx
+++ b/src/pages/NoPageFound.jsx
@@ -1,42 +1,76 @@
+// React Imports
+import { useEffect, useState } from 'react';
 // React Router Imports
 import { useNavigate } from 'react-router-dom';
 // Material UI Imports
 import Box from '@mui/material/Box';
-import Card from '@mui/material/Card';
-import CardActions from '@mui/material/CardActions';
-import CardContent from '@mui/material/CardContent';
-import CardMedia from '@mui/material/CardMedia';
 import Button from '@mui/material/Button';
+import Container from '@mui/material/Container';
+import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 
 const NoPageFound = () => {
   const navigate = useNavigate();
+  const [photoUrl, setPhotoUrl] = useState(null);
+
+  useEffect(() => {
+    fetch('https://api.nasa.gov/planetary/apod?api_key=DEMO_KEY')
+      .then((response) => response.json())
+      .then((data) => {
+        // Check if the URL is a video
+        const urlIsVideo = data.media_type === 'video';
+        // If it isn't a video, set the photoUrl
+        if (!urlIsVideo) {
+          setPhotoUrl(data.url);
+        }
+      })
+      .catch((error) => console.error(error));
+  }, [photoUrl]);
+
+  const isPhotoFound = photoUrl !== null && photoUrl !== undefined;
+
+  const primaryText = isPhotoFound
+    ? 'You are lost in internet space!'
+    : "We can't find that page even with this spotlight!";
+
+  const buttonText = isPhotoFound ? 'Take me back to earth' : 'Take me back';
 
   return (
-    <Box display="flex" alignItems="center" justifyContent="center" height={`calc(100vh - 200px)`}>
-      <Card sx={{ maxWidth: { xs: 250, sm: 350, md: 4525 } }} align="center">
-        <CardMedia
-          image="./assets/notfound.webp"
-          title="Page Not Found"
-          sx={{ height: { xs: 150, sm: 250, md: 350 } }}
-        />
-        <CardContent>
-          <Typography gutterBottom variant="h5" component="div">
-            404: Page Not Found
+    <Box
+      width="100vw"
+      height="calc(100vh - 100px)"
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      sx={{
+        background: `${
+          photoUrl ? `url(${photoUrl})` : `url(/assets/notfound.webp)`
+        } center/cover no-repeat`
+      }}
+    >
+      <Stack
+        alignItems="center"
+        textAlign="center"
+        spacing={4}
+        sx={{
+          backdropFilter: 'blur(16px) saturate(180%)',
+          WebkitBackdropFilter: 'blur(16px) saturate(180%)',
+          backgroundColor: 'rgba(17, 25, 40, 0.5)',
+          border: '1px solid rgba(236, 236, 236, 0.1)',
+          borderRadius: '10px'
+        }}
+      >
+        <Container maxWidth="sm">
+          <Typography variant="h2" color="primary" mb={2}>
+            {primaryText}
           </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Sorry, but this page cannot be found. Click the button below to go back.
-          </Typography>
-        </CardContent>
-        <CardActions sx={{ display: 'flex', justifyContent: 'center' }}>
-          {/* takes to previous page in browser history
-          OR
-          HOME.JSX if no previous browser history */}
+          {/* takes to previous page in browser history OR HOME.JSX if no previous browser history */}
           <Button size="large" variant="contained" onClick={() => navigate(-1) || navigate('/')}>
-            Go Back
+            {buttonText}
           </Button>
-        </CardActions>
-      </Card>
+        </Container>
+        <Typography color="primary">Error 404: Page Not Found</Typography>
+      </Stack>
     </Box>
   );
 };

--- a/src/pages/NoPageFound.jsx
+++ b/src/pages/NoPageFound.jsx
@@ -12,6 +12,7 @@ import Typography from '@mui/material/Typography';
 const NoPageFound = () => {
   const navigate = useNavigate();
   const [photoUrl, setPhotoUrl] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     fetch('https://api.nasa.gov/planetary/apod?api_key=DEMO_KEY')
@@ -23,8 +24,12 @@ const NoPageFound = () => {
         if (!urlIsVideo) {
           setPhotoUrl(data.url);
         }
+        setIsLoading(false);
       })
-      .catch((error) => console.error(error));
+      .catch((error) => {
+        console.error(error);
+        setIsLoading(false);
+      });
   }, []);
 
   const isPhotoFound = photoUrl !== null && photoUrl !== undefined;
@@ -35,6 +40,16 @@ const NoPageFound = () => {
 
   const buttonText = isPhotoFound ? 'Take me back to earth' : 'Take me back';
 
+  let backgroundStyle;
+
+  if (isLoading) {
+    backgroundStyle = 'rgba(0, 0, 0, 0.87)';
+  } else if (photoUrl) {
+    backgroundStyle = `url(${photoUrl}) center/cover no-repeat`;
+  } else {
+    backgroundStyle = 'url(/assets/notfound.webp) center/cover no-repeat';
+  }
+
   return (
     <Box
       width="100vw"
@@ -43,25 +58,40 @@ const NoPageFound = () => {
       alignItems="center"
       justifyContent="center"
       sx={{
-        background: `${
-          photoUrl ? `url(${photoUrl})` : `url(/assets/notfound.webp)`
-        } center/cover no-repeat`
+        background: backgroundStyle
       }}
     >
       <Stack
         alignItems="center"
         textAlign="center"
         spacing={4}
+        p="25px"
         sx={{
-          backdropFilter: 'blur(16px) saturate(180%)',
-          WebkitBackdropFilter: 'blur(16px) saturate(180%)',
+          backdropFilter: 'blur(5px) saturate(180%)',
+          WebkitBackdropFilter: 'blur(5px) saturate(180%)',
           backgroundColor: 'rgba(17, 25, 40, 0.5)',
           border: '1px solid rgba(236, 236, 236, 0.1)',
           borderRadius: '10px'
         }}
       >
         <Container maxWidth="sm">
-          <Typography variant="h2" color="primary" mb={2}>
+          <Typography
+            variant="body1"
+            component="h1"
+            color="secondary"
+            fontSize="24px"
+            sx={{ textShadow: '0px 4px 4px #0000004D' }}
+          >
+            Error 404:
+            <br />
+            Page Not Found
+          </Typography>
+          <Typography
+            variant="h4"
+            color="primary"
+            my="2rem"
+            sx={{ textShadow: '0px 4px 4px #0000004D' }}
+          >
             {primaryText}
           </Typography>
           {/* takes to previous page in browser history OR HOME.JSX if no previous browser history */}
@@ -69,7 +99,6 @@ const NoPageFound = () => {
             {buttonText}
           </Button>
         </Container>
-        <Typography color="primary">Error 404: Page Not Found</Typography>
       </Stack>
     </Box>
   );

--- a/src/pages/NoPageFound.jsx
+++ b/src/pages/NoPageFound.jsx
@@ -88,6 +88,7 @@ const NoPageFound = () => {
           </Typography>
           <Typography
             variant="h4"
+            component="p"
             color="primary"
             my="2rem"
             sx={{ textShadow: '0px 4px 4px #0000004D' }}


### PR DESCRIPTION
## This PR:

Resolves #59

---

## Screenshots:

If API call is successful & doesn't return a video (which is an option):
<img width="1440" alt="Screenshot 2023-11-12 at 12 03 38 PM" src="https://github.com/codeforpdx/codepdx_website/assets/71395931/9451c0ad-674b-4490-b959-379cfb2aa1de">


If API call is unsuccessful or returns a video:
<img width="1437" alt="Screenshot 2023-11-12 at 11 52 37 AM" src="https://github.com/codeforpdx/codepdx_website/assets/71395931/550723d8-4fc4-409b-987d-a346cd247155">


There is still the footer below the full screen photo.

---

## Future Steps/PRs Needed to Finish This Work (optional):

Any styling or code quality discussions