### PR TITLE
Issue 54/contact us modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
-  "name": "code-pdx-website",
+  "name": "codepdx_website",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "code-pdx-website",
+      "name": "codepdx_website",
       "version": "0.0.0",
       "dependencies": {
+        "@emailjs/browser": "^3.11.0",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.14.13",
@@ -246,6 +247,14 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emailjs/browser": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@emailjs/browser/-/browser-3.11.0.tgz",
+      "integrity": "sha512-RkY3FKZ3fPdK++OeF46mRTFpmmQWCHUVHZH209P3NE4D5sg2Atg7S2wa3gw5062Gl4clt4Wn5SyC4WhlVZC5pA==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -4780,6 +4789,11 @@
         "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@emailjs/browser": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@emailjs/browser/-/browser-3.11.0.tgz",
+      "integrity": "sha512-RkY3FKZ3fPdK++OeF46mRTFpmmQWCHUVHZH209P3NE4D5sg2Atg7S2wa3gw5062Gl4clt4Wn5SyC4WhlVZC5pA=="
     },
     "@emotion/babel-plugin": {
       "version": "11.11.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@emailjs/browser": "^3.11.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.14.13",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,8 +2,8 @@ import { useState } from 'react';
 // React Router Imports
 import { BrowserRouter } from 'react-router-dom';
 // Material UI Imports
-import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
+import { ThemeProvider } from '@mui/material/styles';
 // Theme Imports
 import getTheme from './theme';
 // Component Imports

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+// React Imports
 import { useState } from 'react';
 // React Router Imports
 import { BrowserRouter } from 'react-router-dom';

--- a/src/components/global/ContactFormModal.jsx
+++ b/src/components/global/ContactFormModal.jsx
@@ -3,6 +3,7 @@ import { useRef } from 'react';
 // emailjs Imports
 import emailjs from '@emailjs/browser';
 // Material UI Imports
+// import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -43,6 +44,10 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
       sx={{
         display: 'flex',
         flexDirection: 'column'
+        // justifyContent: 'center',
+        // alignItems: 'center',
+        // alignContent: 'center',
+        // alignText: 'center'
       }}
     >
       <Box
@@ -50,12 +55,43 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
         ref={form}
         onSubmit={handleSubmit}
         sx={{
+          // display: 'flex',
+          // flexDirection: 'column',
+          // justifyContent: 'center',
+          // alignItems: 'center',
+          // alignContent: 'center',
+          // alignText: 'center'
           p: { xs: 0, md: 4 }
         }}
       >
-        <DialogTitle>Contact Us</DialogTitle>
+        <DialogTitle
+          sx={
+            {
+              // display: 'flex',
+              // flexDirection: 'column',
+              // justifyContent: 'center',
+              // alignItems: 'center',
+              // alignContent: 'center',
+              // alignText: 'center'
+            }
+          }
+        >
+          Contact Us
+        </DialogTitle>
         <DialogContent>
-          <DialogContentText>
+          <DialogContentText
+            sx={
+              {
+                // display: 'flex',
+                // flexDirection: 'column',
+                // justifyContent: 'center',
+                // alignItems: 'center',
+                // alignContent: 'center',
+                // alignText: 'center'
+                // pb: '1rem',
+              }
+            }
+          >
             For any questions or to just reach out, contact us today!
           </DialogContentText>
           <TextField
@@ -131,6 +167,11 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
           </Grid>
         </DialogActions>
       </Box>
+      {/* {cleared && (
+        <Alert sx={{ position: 'absolute', bottom: 0, right: 0 }} severity="success">
+          Field cleared!
+        </Alert>
+      )} */}
     </Dialog>
   );
 };

--- a/src/components/global/ContactFormModal.jsx
+++ b/src/components/global/ContactFormModal.jsx
@@ -1,5 +1,7 @@
 // React Imports
-import { useState } from 'react';
+import { useRef } from 'react';
+// emailjs Imports
+import emailjs from '@emailjs/browser';
 // Material UI Imports
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -14,33 +16,29 @@ import TextField from '@mui/material/TextField';
 import { PropTypes } from 'prop-types';
 
 const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => {
-  const [name, setName] = useState('');
-  const [message, setMessage] = useState('');
-  const [email, setEmail] = useState('');
+  const form = useRef();
 
   const handleClose = () => {
     setShowContactFormModal(false);
-    setName('');
-    setMessage('');
-    setEmail('');
   };
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    setName(e.target[0].form[0].value);
-    setMessage(e.target[1].form[1].value);
-    setEmail(e.target[2].form[2].value);
-    console.log(e.target[0].form[0].value);
-    console.log(e.target[1].form[1].value);
-    console.log(e.target[2].form[2].value);
-    setName('');
-    setMessage('');
-    setEmail('');
+
+    emailjs.sendForm('service_co2agxf', 'template_20pnwni', form.current, 'AkBl59Ya3226OfPyQ').then(
+      (result) => {
+        console.log(result.text);
+      },
+      (error) => {
+        console.log(error.text);
+      }
+    );
+    e.target.reset();
   };
 
   return (
-    <Dialog open={showContactFormModal} onClose={() => handleClose}>
-      <form onSubmit={handleSubmit} autoComplete="off">
+    <Dialog open={showContactFormModal} onClose={handleClose}>
+      <form ref={form} onSubmit={handleSubmit} autoComplete="off">
         <Box
           sx={{
             p: { xs: 0, md: 4 }
@@ -57,6 +55,7 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
               id="name"
               label="Name"
               type="text"
+              name="name"
               fullWidth
               variant="standard"
               required
@@ -67,6 +66,7 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
               id="email"
               label="Email Address"
               type="email"
+              name="email"
               fullWidth
               variant="standard"
               required
@@ -74,9 +74,10 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
             <TextField
               autoFocus
               margin="dense"
-              id="name"
+              id="message"
               label="Message"
               type="text"
+              name="message"
               fullWidth
               variant="standard"
               multiline
@@ -118,7 +119,7 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
 
 ContactFormModal.propTypes = {
   showContactFormModal: PropTypes.bool,
-  setShowContactFormModal: PropTypes.bool
+  setShowContactFormModal: PropTypes.func
 };
 
 export default ContactFormModal;

--- a/src/components/global/ContactFormModal.jsx
+++ b/src/components/global/ContactFormModal.jsx
@@ -1,56 +1,100 @@
 // React Imports
 import { useState } from 'react';
 // Material UI Imports
+import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
+import Grid from '@mui/material/Grid';
 import TextField from '@mui/material/TextField';
 
 const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => {
-  const [name, setName] = useState('');
   const [email, setEmail] = useState('');
 
   const handleClose = () => {
     setShowContactFormModal(false);
+    setEmail('');
   };
 
-  const handleSubmit = () => {
-    console.log('Submitted!');
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setEmail(e.target.value);
+    console.log(`Email is: ${e}`);
+    setEmail('');
   };
 
   return (
     <Dialog
       open={showContactFormModal}
       onClose={() => setShowContactFormModal(false)}
+      sx={
+        {
+          // backgroundColor: 'red'
+          // display: 'flex',
+          // flexDirection: 'column',
+          // alignText: 'center'
+          // p: '50px'
+        }
+      }
     >
-      <DialogTitle
-      >
-        Contact Us
-      </DialogTitle>
-      <DialogContent>
-        <DialogContentText
+      <form onSubmit={handleSubmit} autoComplete="off">
+        <Box
+          sx={{
+            p: 4,
+            display: 'flex',
+            flexDirection: 'column'
+            // alignContent: 'center',
+            // justifyContent: 'center'
+          }}
         >
-          For any questions or to just reach out, contact us today!
-        </DialogContentText>
-        <TextField
-          autoFocus
-          margin="dense"
-          id="name"
-          label="Email Address"
-          type="email"
-          fullWidth
-          variant="standard"
-        />
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleClose}>Cancel</Button>
-        <Button onClick={handleSubmit} autoFocus>
-          Submit
-        </Button>
-      </DialogActions>
+          <DialogTitle>Contact Us</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              For any questions or to just reach out, contact us today!
+            </DialogContentText>
+            <TextField
+              autoFocus
+              margin="dense"
+              id="name"
+              label="Email Address"
+              type="email"
+              fullWidth
+              variant="standard"
+            />
+          </DialogContent>
+          <DialogActions>
+            <Grid container spacing={1}>
+              <Grid item xs={12} sm={6}>
+                <Button
+                  color="error"
+                  variant="outlined"
+                  onClick={handleClose}
+                  fullWidth
+                  sx={{ borderRadius: 5 }}
+                >
+                  Cancel
+                </Button>
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <Button
+                  type="submit"
+                  color="success"
+                  variant="contained"
+                  // onClick={handleSubmit}
+                  // onChange={}
+                  fullWidth
+                  sx={{ borderRadius: 5 }}
+                >
+                  Submit
+                </Button>
+              </Grid>
+            </Grid>
+          </DialogActions>
+        </Box>
+      </form>
     </Dialog>
   );
 };

--- a/src/components/global/ContactFormModal.jsx
+++ b/src/components/global/ContactFormModal.jsx
@@ -12,45 +12,39 @@ import Grid from '@mui/material/Grid';
 import TextField from '@mui/material/TextField';
 
 const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => {
+  const [name, setName] = useState('');
+  const [message, setMessage] = useState('');
   const [email, setEmail] = useState('');
 
   const handleClose = () => {
     setShowContactFormModal(false);
+    setName('');
+    setMessage('');
     setEmail('');
   };
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    setEmail(e.target.value);
-    console.log(`Email is: ${e.target.value}`);
+    setName(e.target[0].form[0].value);
+    setMessage(e.target[1].form[1].value);
+    setEmail(e.target[2].form[2].value);
+    console.log(e.target[0].form[0].value);
+    console.log(e.target[1].form[1].value);
+    console.log(e.target[2].form[2].value);
+    setName('');
+    setMessage('');
     setEmail('');
   };
 
   return (
-    <Dialog
-      open={showContactFormModal}
-      onClose={() => setShowContactFormModal(false)}
-      sx={
-        {
-          // backgroundColor: 'red'
-          // display: 'flex',
-          // flexDirection: 'column',
-          // alignText: 'center'
-          // p: '50px'
-        }
-      }
-    >
+    <Dialog open={showContactFormModal} onClose={() => setShowContactFormModal(false)}>
       <form onSubmit={handleSubmit} autoComplete="off">
         <Box
           sx={{
-            p: 4,
-            display: 'flex',
-            flexDirection: 'column'
-            // alignContent: 'center',
-            // justifyContent: 'center'
+            p: { xs: 0, md: 4 }
           }}
         >
-          <DialogTitle>Contact Us</DialogTitle>
+          <DialogTitle sx={{ display: 'flex', justifyContent: 'center' }}>Contact Us</DialogTitle>
           <DialogContent>
             <DialogContentText>
               For any questions or to just reach out, contact us today!
@@ -59,10 +53,33 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
               autoFocus
               margin="dense"
               id="name"
+              label="Name"
+              type="text"
+              fullWidth
+              variant="standard"
+              required
+            />
+            <TextField
+              autoFocus
+              margin="dense"
+              id="email"
               label="Email Address"
               type="email"
               fullWidth
               variant="standard"
+              required
+            />
+            <TextField
+              autoFocus
+              margin="dense"
+              id="name"
+              label="Message"
+              type="text"
+              fullWidth
+              variant="standard"
+              multiline
+              rows={5}
+              required
             />
           </DialogContent>
           <DialogActions>
@@ -83,8 +100,6 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
                   type="submit"
                   color="success"
                   variant="contained"
-                  // onClick={handleSubmit}
-                  // onChange={}
                   fullWidth
                   sx={{ borderRadius: 5 }}
                 >

--- a/src/components/global/ContactFormModal.jsx
+++ b/src/components/global/ContactFormModal.jsx
@@ -103,7 +103,7 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
             name="name"
             fullWidth
             variant="standard"
-            autocomplete
+            autoComplete="true"
             required
           />
           <TextField
@@ -114,7 +114,7 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
             name="email"
             fullWidth
             variant="standard"
-            autocomplete
+            autoComplete="true"
             required
           />
           <TextField

--- a/src/components/global/ContactFormModal.jsx
+++ b/src/components/global/ContactFormModal.jsx
@@ -10,6 +10,8 @@ import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 import Grid from '@mui/material/Grid';
 import TextField from '@mui/material/TextField';
+// Other Library Imports
+import { PropTypes } from 'prop-types';
 
 const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => {
   const [name, setName] = useState('');
@@ -37,7 +39,7 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
   };
 
   return (
-    <Dialog open={showContactFormModal} onClose={() => setShowContactFormModal(false)}>
+    <Dialog open={showContactFormModal} onClose={() => handleClose}>
       <form onSubmit={handleSubmit} autoComplete="off">
         <Box
           sx={{
@@ -112,6 +114,11 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
       </form>
     </Dialog>
   );
+};
+
+ContactFormModal.propTypes = {
+  showContactFormModal: PropTypes.bool,
+  setShowContactFormModal: PropTypes.bool
 };
 
 export default ContactFormModal;

--- a/src/components/global/ContactFormModal.jsx
+++ b/src/components/global/ContactFormModal.jsx
@@ -15,6 +15,8 @@ import TextField from '@mui/material/TextField';
 // Other Library Imports
 import { PropTypes } from 'prop-types';
 
+// TODO: Change title from "Contact Us" to "Volunteer" if using that button?
+
 const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => {
   const form = useRef();
 
@@ -46,7 +48,7 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
         >
           <DialogTitle sx={{ display: 'flex', justifyContent: 'center' }}>Contact Us</DialogTitle>
           <DialogContent>
-            <DialogContentText>
+            <DialogContentText sx={{ pb: '1rem' }}>
               For any questions or to just reach out, contact us today!
             </DialogContentText>
             <TextField

--- a/src/components/global/ContactFormModal.jsx
+++ b/src/components/global/ContactFormModal.jsx
@@ -24,11 +24,14 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
   const handleSubmit = (e) => {
     e.preventDefault();
 
-    emailjs
-      .sendForm('service_co2agxf', 'template_20pnwni', form.current, 'AkBl59Ya3226OfPyQ')
-      .then((result) => {
+    emailjs.sendForm('service_co2agxf', 'template_20pnwni', form.current, 'AkBl59Ya3226OfPyQ').then(
+      (result) => {
         console.log(result.text);
-      }, console.error());
+      },
+      (error) => {
+        console.error(error.text);
+      }
+    );
     e.target.reset();
     setTimeout(() => {
       setShowContactFormModal(false);
@@ -40,8 +43,6 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
       open={showContactFormModal}
       onClose={handleClose}
       sx={{
-        display: 'flex',
-        flexDirection: 'column',
         textAlign: 'center'
       }}
     >
@@ -100,12 +101,12 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
             fullWidth
             variant="standard"
             multiline
-            rows={5}
+            rows={4}
             required
           />
         </DialogContent>
         <DialogActions>
-          <Grid container spacing={1}>
+          <Grid container spacing={1} px={2}>
             <Grid item xs={12} sm={6}>
               <Button
                 color="error"

--- a/src/components/global/ContactFormModal.jsx
+++ b/src/components/global/ContactFormModal.jsx
@@ -74,6 +74,17 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
             <TextField
               autoFocus
               margin="dense"
+              id="subject"
+              label="Subject"
+              type="text"
+              name="subject"
+              fullWidth
+              variant="standard"
+              required
+            />
+            <TextField
+              autoFocus
+              margin="dense"
               id="message"
               label="Message"
               type="text"

--- a/src/components/global/ContactFormModal.jsx
+++ b/src/components/global/ContactFormModal.jsx
@@ -15,8 +15,6 @@ import TextField from '@mui/material/TextField';
 // Other Library Imports
 import { PropTypes } from 'prop-types';
 
-// TODO: Change title from "Contact Us" to "Volunteer" if using that button?
-
 const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => {
   const form = useRef();
 
@@ -27,105 +25,112 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
   const handleSubmit = (e) => {
     e.preventDefault();
 
-    emailjs.sendForm('service_co2agxf', 'template_20pnwni', form.current, 'AkBl59Ya3226OfPyQ').then(
-      (result) => {
+    emailjs
+      .sendForm('service_co2agxf', 'template_20pnwni', form.current, 'AkBl59Ya3226OfPyQ')
+      .then((result) => {
         console.log(result.text);
-      },
-      (error) => {
-        console.log(error.text);
-      }
-    );
+      }, console.error());
     e.target.reset();
+    setTimeout(() => {
+      setShowContactFormModal(false);
+    }, 2000);
   };
 
   return (
-    <Dialog open={showContactFormModal} onClose={handleClose}>
-      <form ref={form} onSubmit={handleSubmit} autoComplete="off">
-        <Box
-          sx={{
-            p: { xs: 0, md: 4 }
-          }}
-        >
-          <DialogTitle sx={{ display: 'flex', justifyContent: 'center' }}>Contact Us</DialogTitle>
-          <DialogContent>
-            <DialogContentText sx={{ pb: '1rem' }}>
-              For any questions or to just reach out, contact us today!
-            </DialogContentText>
-            <TextField
-              autoFocus
-              margin="dense"
-              id="name"
-              label="Name"
-              type="text"
-              name="name"
-              fullWidth
-              variant="standard"
-              required
-            />
-            <TextField
-              autoFocus
-              margin="dense"
-              id="email"
-              label="Email Address"
-              type="email"
-              name="email"
-              fullWidth
-              variant="standard"
-              required
-            />
-            <TextField
-              autoFocus
-              margin="dense"
-              id="subject"
-              label="Subject"
-              type="text"
-              name="subject"
-              fullWidth
-              variant="standard"
-              required
-            />
-            <TextField
-              autoFocus
-              margin="dense"
-              id="message"
-              label="Message"
-              type="text"
-              name="message"
-              fullWidth
-              variant="standard"
-              multiline
-              rows={5}
-              required
-            />
-          </DialogContent>
-          <DialogActions>
-            <Grid container spacing={1}>
-              <Grid item xs={12} sm={6}>
-                <Button
-                  color="error"
-                  variant="outlined"
-                  onClick={handleClose}
-                  fullWidth
-                  sx={{ borderRadius: 5 }}
-                >
-                  Cancel
-                </Button>
-              </Grid>
-              <Grid item xs={12} sm={6}>
-                <Button
-                  type="submit"
-                  color="success"
-                  variant="contained"
-                  fullWidth
-                  sx={{ borderRadius: 5 }}
-                >
-                  Submit
-                </Button>
-              </Grid>
+    <Dialog
+      open={showContactFormModal}
+      onClose={handleClose}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column'
+      }}
+    >
+      <Box
+        component="form"
+        ref={form}
+        onSubmit={handleSubmit}
+        sx={{
+          p: { xs: 0, md: 4 }
+        }}
+      >
+        <DialogTitle>Contact Us</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            For any questions or to just reach out, contact us today!
+          </DialogContentText>
+          <TextField
+            autoFocus
+            margin="dense"
+            id="name"
+            label="Name"
+            type="text"
+            name="name"
+            fullWidth
+            variant="standard"
+            autocomplete
+            required
+          />
+          <TextField
+            margin="dense"
+            id="email"
+            label="Email Address"
+            type="email"
+            name="email"
+            fullWidth
+            variant="standard"
+            autocomplete
+            required
+          />
+          <TextField
+            margin="dense"
+            id="subject"
+            label="Subject"
+            type="text"
+            name="subject"
+            fullWidth
+            variant="standard"
+            required
+          />
+          <TextField
+            margin="dense"
+            id="message"
+            label="Message"
+            type="text"
+            name="message"
+            fullWidth
+            variant="standard"
+            multiline
+            rows={5}
+            required
+          />
+        </DialogContent>
+        <DialogActions>
+          <Grid container spacing={1}>
+            <Grid item xs={12} sm={6}>
+              <Button
+                color="error"
+                variant="outlined"
+                onClick={handleClose}
+                fullWidth
+                sx={{ borderRadius: 5 }}
+              >
+                Cancel
+              </Button>
             </Grid>
-          </DialogActions>
-        </Box>
-      </form>
+            <Grid item xs={12} sm={6}>
+              <Button
+                type="submit"
+                color="success"
+                variant="contained"
+                fullWidth
+                sx={{ borderRadius: 5 }}
+              >
+                Submit
+              </Button>
+            </Grid>
+          </Grid>
+        </DialogActions>
+      </Box>
     </Dialog>
   );
 };

--- a/src/components/global/ContactFormModal.jsx
+++ b/src/components/global/ContactFormModal.jsx
@@ -1,9 +1,6 @@
 // React Imports
 import { useRef } from 'react';
-// emailjs Imports
-import emailjs from '@emailjs/browser';
 // Material UI Imports
-// import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -14,6 +11,7 @@ import DialogTitle from '@mui/material/DialogTitle';
 import Grid from '@mui/material/Grid';
 import TextField from '@mui/material/TextField';
 // Other Library Imports
+import emailjs from '@emailjs/browser';
 import { PropTypes } from 'prop-types';
 
 const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => {
@@ -34,7 +32,7 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
     e.target.reset();
     setTimeout(() => {
       setShowContactFormModal(false);
-    }, 2000);
+    }, 500);
   };
 
   return (
@@ -43,11 +41,8 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
       onClose={handleClose}
       sx={{
         display: 'flex',
-        flexDirection: 'column'
-        // justifyContent: 'center',
-        // alignItems: 'center',
-        // alignContent: 'center',
-        // alignText: 'center'
+        flexDirection: 'column',
+        textAlign: 'center'
       }}
     >
       <Box
@@ -55,43 +50,12 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
         ref={form}
         onSubmit={handleSubmit}
         sx={{
-          // display: 'flex',
-          // flexDirection: 'column',
-          // justifyContent: 'center',
-          // alignItems: 'center',
-          // alignContent: 'center',
-          // alignText: 'center'
           p: { xs: 0, md: 4 }
         }}
       >
-        <DialogTitle
-          sx={
-            {
-              // display: 'flex',
-              // flexDirection: 'column',
-              // justifyContent: 'center',
-              // alignItems: 'center',
-              // alignContent: 'center',
-              // alignText: 'center'
-            }
-          }
-        >
-          Contact Us
-        </DialogTitle>
+        <DialogTitle>Contact Us</DialogTitle>
         <DialogContent>
-          <DialogContentText
-            sx={
-              {
-                // display: 'flex',
-                // flexDirection: 'column',
-                // justifyContent: 'center',
-                // alignItems: 'center',
-                // alignContent: 'center',
-                // alignText: 'center'
-                // pb: '1rem',
-              }
-            }
-          >
+          <DialogContentText>
             For any questions or to just reach out, contact us today!
           </DialogContentText>
           <TextField
@@ -167,11 +131,6 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
           </Grid>
         </DialogActions>
       </Box>
-      {/* {cleared && (
-        <Alert sx={{ position: 'absolute', bottom: 0, right: 0 }} severity="success">
-          Field cleared!
-        </Alert>
-      )} */}
     </Dialog>
   );
 };

--- a/src/components/global/ContactFormModal.jsx
+++ b/src/components/global/ContactFormModal.jsx
@@ -22,7 +22,7 @@ const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => 
   const handleSubmit = (e) => {
     e.preventDefault();
     setEmail(e.target.value);
-    console.log(`Email is: ${e}`);
+    console.log(`Email is: ${e.target.value}`);
     setEmail('');
   };
 

--- a/src/components/global/ContactFormModal.jsx
+++ b/src/components/global/ContactFormModal.jsx
@@ -1,0 +1,58 @@
+// React Imports
+import { useState } from 'react';
+// Material UI Imports
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import TextField from '@mui/material/TextField';
+
+const ContactFormModal = ({ showContactFormModal, setShowContactFormModal }) => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+
+  const handleClose = () => {
+    setShowContactFormModal(false);
+  };
+
+  const handleSubmit = () => {
+    console.log('Submitted!');
+  };
+
+  return (
+    <Dialog
+      open={showContactFormModal}
+      onClose={() => setShowContactFormModal(false)}
+    >
+      <DialogTitle
+      >
+        Contact Us
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText
+        >
+          For any questions or to just reach out, contact us today!
+        </DialogContentText>
+        <TextField
+          autoFocus
+          margin="dense"
+          id="name"
+          label="Email Address"
+          type="email"
+          fullWidth
+          variant="standard"
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button onClick={handleSubmit} autoFocus>
+          Submit
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ContactFormModal;

--- a/src/components/global/Footer.jsx
+++ b/src/components/global/Footer.jsx
@@ -7,7 +7,6 @@ import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
-
 // Other Library Imports
 import dayjs from 'dayjs';
 import { FaDiscord, FaGithub, FaLinkedin, FaMeetup } from 'react-icons/fa6';

--- a/src/components/global/Hero/Hero.jsx
+++ b/src/components/global/Hero/Hero.jsx
@@ -1,9 +1,8 @@
 // Material UI Imports
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import { PropTypes } from 'prop-types';
-//import component specific styles
+// Component Style Imports
 import { heroStyles } from './styles';
 
 const Hero = ({ pageName, heroImage, heroText }) => {
@@ -30,15 +29,6 @@ const Hero = ({ pageName, heroImage, heroText }) => {
           <Typography variant="h1" sx={h1Styles}>
             {heroText}
           </Typography>
-        )}
-        {pageName === 'home' && (
-          <Button
-            variant="contained"
-            href="mailto:hugh@codeforpdx.org"
-            sx={heroStyles.contactBtnStyle}
-          >
-            Contact Us
-          </Button>
         )}
       </Box>
     </Box>

--- a/src/components/global/Hero/Hero.jsx
+++ b/src/components/global/Hero/Hero.jsx
@@ -1,6 +1,7 @@
 // Material UI Imports
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+// Other Library Imports
 import { PropTypes } from 'prop-types';
 // Component Style Imports
 import { heroStyles } from './styles';

--- a/src/components/global/Hero/styles.js
+++ b/src/components/global/Hero/styles.js
@@ -55,17 +55,5 @@ export const heroStyles = {
     width: '80%',
     height: '60%',
     textAlign: 'center'
-  },
-  contactBtnStyle: {
-    textTransform: 'capitalize',
-    fontWeight: '200',
-    color: 'black',
-    textShadow: '0px 4px 4px #0000004D',
-    alignSelf: 'center',
-    mt: '2em',
-    fontSize: { xs: '15px', md: '18px' },
-    width: { xs: '115px', md: '310px' },
-    height: { xs: '25px', md: '84px' },
-    borderRadius: '5px'
   }
 };

--- a/src/components/global/Navbar.jsx
+++ b/src/components/global/Navbar.jsx
@@ -1,3 +1,8 @@
+// React Imports
+import { useState, useRef } from 'react';
+// React Router Imports
+import { Link } from 'react-router-dom';
+// Material UI Imports
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import FormControlLabel from '@mui/material/FormControlLabel';
@@ -12,8 +17,6 @@ import Toolbar from '@mui/material/Toolbar';
 import Switch from '@mui/material/Switch';
 import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material/styles';
-import { Link } from 'react-router-dom';
-import { useState, useRef } from 'react';
 
 const logoBlobStyle = {
   position: 'absolute',

--- a/src/components/global/Navbar.jsx
+++ b/src/components/global/Navbar.jsx
@@ -171,7 +171,7 @@ function NavBar() {
           marginRight={2}
           sx={navTextStyle}
         >
-          <Link to="/volunteer" style={navTextStyle} aria-label="Volunteer for code pdx">
+          <Link to="/volunteer" style={navTextStyle} aria-label="Volunteer for CODE PDX">
             Volunteer
           </Link>
         </Typography>

--- a/src/components/home/Events.jsx
+++ b/src/components/home/Events.jsx
@@ -1,8 +1,9 @@
+// Material UI Imports
+import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
-import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
-import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 
 const leftSidePaperStyles = {
   elevation: 3,

--- a/src/components/home/ProjectsBrief.jsx
+++ b/src/components/home/ProjectsBrief.jsx
@@ -7,7 +7,7 @@ import CardContent from '@mui/material/CardContent';
 import CardMedia from '@mui/material/CardMedia';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
-// Custom Imports
+// Component Imports
 import projectsList from '../projects/projectsList';
 
 const cardStyle = {

--- a/src/components/home/VolunteerBrief.jsx
+++ b/src/components/home/VolunteerBrief.jsx
@@ -1,5 +1,5 @@
 // React Imports
-import { useState } from 'react';
+import { Link } from 'react-router-dom';
 // Material UI Imports
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
@@ -15,8 +15,6 @@ import QueryStatsOutlinedIcon from '@mui/icons-material/QueryStatsOutlined';
 import StorageRoundedIcon from '@mui/icons-material/StorageRounded';
 import TerminalOutlinedIcon from '@mui/icons-material/TerminalOutlined';
 import VolunteerActivismOutlinedIcon from '@mui/icons-material/VolunteerActivismOutlined';
-// Component Imports
-import ContactFormModal from '../global/ContactFormModal';
 
 const volunteerGrid = [
   {
@@ -62,12 +60,6 @@ const volunteerGrid = [
 ];
 
 const VolunteerBrief = () => {
-  const [showContactFormModal, setShowContactFormModal] = useState(false);
-
-  const handleContactForm = () => {
-    setShowContactFormModal(!showContactFormModal);
-  };
-
   return (
     <Stack
       as="section"
@@ -100,18 +92,17 @@ const VolunteerBrief = () => {
         </Grid>
         <Button
           variant="contained"
-          onClick={() => handleContactForm()}
           sx={{
             mt: '2rem'
           }}
+          href="/volunteer"
         >
+          {/* TODO: This is to determine whether we prefer this button to redirect to Volunteer page 
+          rather than the contact form modal. If so, this may need to be wrapped in a "scroll to top" component
+          because it currently switches to the middle of the page  */}
           Volunteer
         </Button>
       </Card>
-      <ContactFormModal
-        showContactFormModal={showContactFormModal}
-        setShowContactFormModal={setShowContactFormModal}
-      />
     </Stack>
   );
 };

--- a/src/components/home/VolunteerBrief.jsx
+++ b/src/components/home/VolunteerBrief.jsx
@@ -1,3 +1,5 @@
+// React Imports
+import { useState } from 'react';
 // Material UI Imports
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
@@ -13,6 +15,8 @@ import QueryStatsOutlinedIcon from '@mui/icons-material/QueryStatsOutlined';
 import StorageRoundedIcon from '@mui/icons-material/StorageRounded';
 import TerminalOutlinedIcon from '@mui/icons-material/TerminalOutlined';
 import VolunteerActivismOutlinedIcon from '@mui/icons-material/VolunteerActivismOutlined';
+// Custom Imports
+import ContactFormModal from '../global/ContactFormModal';
 
 const volunteerGrid = [
   {
@@ -58,6 +62,12 @@ const volunteerGrid = [
 ];
 
 const VolunteerBrief = () => {
+  const [showContactFormModal, setShowContactFormModal] = useState(false);
+
+  const handleContactForm = () => {
+    setShowContactFormModal(!showContactFormModal);
+  };
+
   return (
     <Stack
       as="section"
@@ -90,9 +100,9 @@ const VolunteerBrief = () => {
         </Grid>
         <Button
           variant="contained"
-          href="mailto:hugh@codeforpdx.org"
           target="_blank"
           rel="noopener"
+          onClick={handleContactForm}
           sx={{
             mt: '2rem'
           }}
@@ -100,6 +110,10 @@ const VolunteerBrief = () => {
           Volunteer
         </Button>
       </Card>
+      <ContactFormModal
+        showContactFormModal={showContactFormModal}
+        setShowContactFormModal={setShowContactFormModal}
+      />
     </Stack>
   );
 };

--- a/src/components/home/VolunteerBrief.jsx
+++ b/src/components/home/VolunteerBrief.jsx
@@ -15,7 +15,7 @@ import QueryStatsOutlinedIcon from '@mui/icons-material/QueryStatsOutlined';
 import StorageRoundedIcon from '@mui/icons-material/StorageRounded';
 import TerminalOutlinedIcon from '@mui/icons-material/TerminalOutlined';
 import VolunteerActivismOutlinedIcon from '@mui/icons-material/VolunteerActivismOutlined';
-// Custom Imports
+// Component Imports
 import ContactFormModal from '../global/ContactFormModal';
 
 const volunteerGrid = [

--- a/src/components/home/VolunteerBrief.jsx
+++ b/src/components/home/VolunteerBrief.jsx
@@ -1,5 +1,3 @@
-// React Imports
-// import { useState } from 'react';
 // Material UI Imports
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
@@ -15,8 +13,8 @@ import QueryStatsOutlinedIcon from '@mui/icons-material/QueryStatsOutlined';
 import StorageRoundedIcon from '@mui/icons-material/StorageRounded';
 import TerminalOutlinedIcon from '@mui/icons-material/TerminalOutlined';
 import VolunteerActivismOutlinedIcon from '@mui/icons-material/VolunteerActivismOutlined';
-// Component Imports
-// import ContactFormModal from '../global/ContactFormModal';
+// Other Library Imports
+import { PropTypes } from 'prop-types';
 
 const volunteerGrid = [
   {
@@ -61,13 +59,7 @@ const volunteerGrid = [
   }
 ];
 
-const VolunteerBrief = (handleContactForm) => {
-  // const [showContactFormModal, setShowContactFormModal] = useState(false);
-
-  // const handleContactForm = () => {
-  //   setShowContactFormModal(!showContactFormModal);
-  // };
-
+const VolunteerBrief = ({ handleContactForm }) => {
   return (
     <Stack
       as="section"
@@ -100,7 +92,7 @@ const VolunteerBrief = (handleContactForm) => {
         </Grid>
         <Button
           variant="contained"
-          onClick={handleContactForm}
+          onClick={() => handleContactForm()}
           sx={{
             mt: '2rem'
           }}
@@ -108,12 +100,12 @@ const VolunteerBrief = (handleContactForm) => {
           Volunteer
         </Button>
       </Card>
-      {/* <ContactFormModal
-        showContactFormModal={showContactFormModal}
-        setShowContactFormModal={setShowContactFormModal}
-      /> */}
     </Stack>
   );
+};
+
+VolunteerBrief.propTypes = {
+  handleContactForm: PropTypes.func
 };
 
 export default VolunteerBrief;

--- a/src/components/home/VolunteerBrief.jsx
+++ b/src/components/home/VolunteerBrief.jsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+import { Link } from 'react-router-dom';
 // Material UI Imports
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
@@ -58,6 +60,10 @@ const volunteerGrid = [
 ];
 
 const VolunteerBrief = () => {
+  const scrollToTop = () => {
+    window.scrollTo(0, 0);
+  };
+
   return (
     <Stack
       as="section"
@@ -93,12 +99,18 @@ const VolunteerBrief = () => {
           sx={{
             mt: '2rem'
           }}
-          href="/volunteer"
+          onClick={scrollToTop}
         >
-          {/* TODO: This is to determine whether we prefer this button to redirect to Volunteer page 
-          rather than the contact form modal. If so, this may need to be wrapped in a "scroll to top" component
-          because it currently switches to the middle of the page  */}
-          Volunteer
+          <Link
+            to="/volunteer"
+            style={{
+              textDecoration: 'none',
+              color: 'inherit'
+            }}
+            aria-label="Volunteer for CODE PDX"
+          >
+            Volunteer
+          </Link>
         </Button>
       </Card>
     </Stack>

--- a/src/components/home/VolunteerBrief.jsx
+++ b/src/components/home/VolunteerBrief.jsx
@@ -1,5 +1,5 @@
 // React Imports
-import { useState } from 'react';
+// import { useState } from 'react';
 // Material UI Imports
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
@@ -16,7 +16,7 @@ import StorageRoundedIcon from '@mui/icons-material/StorageRounded';
 import TerminalOutlinedIcon from '@mui/icons-material/TerminalOutlined';
 import VolunteerActivismOutlinedIcon from '@mui/icons-material/VolunteerActivismOutlined';
 // Component Imports
-import ContactFormModal from '../global/ContactFormModal';
+// import ContactFormModal from '../global/ContactFormModal';
 
 const volunteerGrid = [
   {
@@ -61,12 +61,12 @@ const volunteerGrid = [
   }
 ];
 
-const VolunteerBrief = () => {
-  const [showContactFormModal, setShowContactFormModal] = useState(false);
+const VolunteerBrief = (handleContactForm) => {
+  // const [showContactFormModal, setShowContactFormModal] = useState(false);
 
-  const handleContactForm = () => {
-    setShowContactFormModal(!showContactFormModal);
-  };
+  // const handleContactForm = () => {
+  //   setShowContactFormModal(!showContactFormModal);
+  // };
 
   return (
     <Stack
@@ -108,10 +108,10 @@ const VolunteerBrief = () => {
           Volunteer
         </Button>
       </Card>
-      <ContactFormModal
+      {/* <ContactFormModal
         showContactFormModal={showContactFormModal}
         setShowContactFormModal={setShowContactFormModal}
-      />
+      /> */}
     </Stack>
   );
 };

--- a/src/components/home/VolunteerBrief.jsx
+++ b/src/components/home/VolunteerBrief.jsx
@@ -1,3 +1,5 @@
+// React Imports
+import { useState } from 'react';
 // Material UI Imports
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
@@ -13,8 +15,8 @@ import QueryStatsOutlinedIcon from '@mui/icons-material/QueryStatsOutlined';
 import StorageRoundedIcon from '@mui/icons-material/StorageRounded';
 import TerminalOutlinedIcon from '@mui/icons-material/TerminalOutlined';
 import VolunteerActivismOutlinedIcon from '@mui/icons-material/VolunteerActivismOutlined';
-// Other Library Imports
-import { PropTypes } from 'prop-types';
+// Component Imports
+import ContactFormModal from '../global/ContactFormModal';
 
 const volunteerGrid = [
   {
@@ -59,7 +61,13 @@ const volunteerGrid = [
   }
 ];
 
-const VolunteerBrief = ({ handleContactForm }) => {
+const VolunteerBrief = () => {
+  const [showContactFormModal, setShowContactFormModal] = useState(false);
+
+  const handleContactForm = () => {
+    setShowContactFormModal(!showContactFormModal);
+  };
+
   return (
     <Stack
       as="section"
@@ -100,12 +108,12 @@ const VolunteerBrief = ({ handleContactForm }) => {
           Volunteer
         </Button>
       </Card>
+      <ContactFormModal
+        showContactFormModal={showContactFormModal}
+        setShowContactFormModal={setShowContactFormModal}
+      />
     </Stack>
   );
-};
-
-VolunteerBrief.propTypes = {
-  handleContactForm: PropTypes.func
 };
 
 export default VolunteerBrief;

--- a/src/components/home/VolunteerBrief.jsx
+++ b/src/components/home/VolunteerBrief.jsx
@@ -100,8 +100,6 @@ const VolunteerBrief = () => {
         </Grid>
         <Button
           variant="contained"
-          target="_blank"
-          rel="noopener"
           onClick={handleContactForm}
           sx={{
             mt: '2rem'

--- a/src/components/home/VolunteerBrief.jsx
+++ b/src/components/home/VolunteerBrief.jsx
@@ -1,5 +1,3 @@
-// React Imports
-import { Link } from 'react-router-dom';
 // Material UI Imports
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';

--- a/src/components/home/VolunteerBrief.jsx
+++ b/src/components/home/VolunteerBrief.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+// React Router Imports
 import { Link } from 'react-router-dom';
 // Material UI Imports
 import Button from '@mui/material/Button';

--- a/src/components/home/partners/CallToAction.jsx
+++ b/src/components/home/partners/CallToAction.jsx
@@ -41,8 +41,6 @@ const CallToAction = () => {
             variant="contained"
             color="primary"
             size="large"
-            target="_blank"
-            rel="noopener"
             onClick={handleContactForm}
           >
             Contact us

--- a/src/components/home/partners/CallToAction.jsx
+++ b/src/components/home/partners/CallToAction.jsx
@@ -1,12 +1,19 @@
+// React Imports
+import { useState } from 'react';
 // Material UI Imports
 import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
-// Other Library Imports
-import { PropTypes } from 'prop-types';
+// Component Imports
+import ContactFormModal from '../../global/ContactFormModal';
 
-const CallToAction = ({ handleContactForm }) => {
+const CallToAction = () => {
+  const [showContactFormModal, setShowContactFormModal] = useState(false);
+
+  const handleContactForm = () => {
+    setShowContactFormModal(!showContactFormModal);
+  };
   return (
     <Container maxWidth="xl" sx={{ pt: '50px', pb: '100px' }}>
       <Grid
@@ -29,12 +36,12 @@ const CallToAction = ({ handleContactForm }) => {
           </Button>
         </Grid>
       </Grid>
+      <ContactFormModal
+        showContactFormModal={showContactFormModal}
+        setShowContactFormModal={setShowContactFormModal}
+      />
     </Container>
   );
-};
-
-CallToAction.propTypes = {
-  handleContactForm: PropTypes.func
 };
 
 export default CallToAction;

--- a/src/components/home/partners/CallToAction.jsx
+++ b/src/components/home/partners/CallToAction.jsx
@@ -1,20 +1,12 @@
-// React Imports
-// import { useState } from 'react';
 // Material UI Imports
 import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
-// Component Imports
-// import ContactFormModal from '../../global/ContactFormModal';
+// Other Library Imports
+import { PropTypes } from 'prop-types';
 
-const CallToAction = (handleContactForm) => {
-  // const [showContactFormModal, setShowContactFormModal] = useState(false);
-
-  // const handleContactForm = () => {
-  //   setShowContactFormModal(!showContactFormModal);
-  // };
-
+const CallToAction = ({ handleContactForm }) => {
   return (
     <Container maxWidth="xl" sx={{ pt: '50px', pb: '100px' }}>
       <Grid
@@ -37,12 +29,12 @@ const CallToAction = (handleContactForm) => {
           </Button>
         </Grid>
       </Grid>
-      {/* <ContactFormModal
-        showContactFormModal={showContactFormModal}
-        setShowContactFormModal={setShowContactFormModal}
-      /> */}
     </Container>
   );
+};
+
+CallToAction.propTypes = {
+  handleContactForm: PropTypes.func
 };
 
 export default CallToAction;

--- a/src/components/home/partners/CallToAction.jsx
+++ b/src/components/home/partners/CallToAction.jsx
@@ -5,7 +5,7 @@ import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
-// Custom Imports
+// Component Imports
 import ContactFormModal from '../../global/ContactFormModal';
 
 const CallToAction = () => {

--- a/src/components/home/partners/CallToAction.jsx
+++ b/src/components/home/partners/CallToAction.jsx
@@ -17,32 +17,22 @@ const CallToAction = (handleContactForm) => {
 
   return (
     <Container maxWidth="xl" sx={{ pt: '50px', pb: '100px' }}>
-      <Grid container spacing={1} alignItems="center">
-        <Grid item xs={12} md={8}>
+      <Grid
+        container
+        spacing={1}
+        alignItems="center"
+        style={{ textAlign: 'center', alignItems: 'center' }}
+      >
+        <Grid item xs={12}>
           <Typography variant="h4" pb={'2rem'}>
             Empower Change: Become a partner in our civic tech movement.
           </Typography>
-          <Typography variant="h4">
+          <Typography variant="h4" pb={'2rem'}>
             Have an idea for a civic project in Portland or want to partner with us?
           </Typography>
         </Grid>
-        <Grid item xs={12} md={4} style={{ textAlign: 'center', alignItems: 'center' }}>
-          <Button
-            sx={{
-              mt: {
-                xs: '50px',
-                md: '0'
-              },
-              mr: {
-                xs: '0px',
-                md: '25%'
-              }
-            }}
-            variant="contained"
-            color="primary"
-            size="large"
-            onClick={handleContactForm}
-          >
+        <Grid item xs={12}>
+          <Button variant="contained" color="primary" size="large" onClick={handleContactForm}>
             Contact us
           </Button>
         </Grid>

--- a/src/components/home/partners/CallToAction.jsx
+++ b/src/components/home/partners/CallToAction.jsx
@@ -1,19 +1,19 @@
 // React Imports
-import { useState } from 'react';
+// import { useState } from 'react';
 // Material UI Imports
 import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 // Component Imports
-import ContactFormModal from '../../global/ContactFormModal';
+// import ContactFormModal from '../../global/ContactFormModal';
 
-const CallToAction = () => {
-  const [showContactFormModal, setShowContactFormModal] = useState(false);
+const CallToAction = (handleContactForm) => {
+  // const [showContactFormModal, setShowContactFormModal] = useState(false);
 
-  const handleContactForm = () => {
-    setShowContactFormModal(!showContactFormModal);
-  };
+  // const handleContactForm = () => {
+  //   setShowContactFormModal(!showContactFormModal);
+  // };
 
   return (
     <Container maxWidth="xl" sx={{ pt: '50px', pb: '100px' }}>
@@ -47,10 +47,10 @@ const CallToAction = () => {
           </Button>
         </Grid>
       </Grid>
-      <ContactFormModal
+      {/* <ContactFormModal
         showContactFormModal={showContactFormModal}
         setShowContactFormModal={setShowContactFormModal}
-      />
+      /> */}
     </Container>
   );
 };

--- a/src/components/home/partners/CallToAction.jsx
+++ b/src/components/home/partners/CallToAction.jsx
@@ -1,9 +1,20 @@
+// React Imports
+import { useState } from 'react';
+// Material UI Imports
 import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
+// Custom Imports
+import ContactFormModal from '../../global/ContactFormModal';
 
 const CallToAction = () => {
+  const [showContactFormModal, setShowContactFormModal] = useState(false);
+
+  const handleContactForm = () => {
+    setShowContactFormModal(!showContactFormModal);
+  };
+
   return (
     <Container maxWidth="xl" sx={{ pt: '50px', pb: '100px' }}>
       <Grid container spacing={1} alignItems="center">
@@ -30,14 +41,18 @@ const CallToAction = () => {
             variant="contained"
             color="primary"
             size="large"
-            href="mailto:hugh@codeforpdx.org"
             target="_blank"
             rel="noopener"
+            onClick={handleContactForm}
           >
             Contact us
           </Button>
         </Grid>
       </Grid>
+      <ContactFormModal
+        showContactFormModal={showContactFormModal}
+        setShowContactFormModal={setShowContactFormModal}
+      />
     </Container>
   );
 };

--- a/src/components/home/partners/CallToAction.jsx
+++ b/src/components/home/partners/CallToAction.jsx
@@ -14,14 +14,10 @@ const CallToAction = () => {
   const handleContactForm = () => {
     setShowContactFormModal(!showContactFormModal);
   };
+
   return (
     <Container maxWidth="xl" sx={{ pt: '50px', pb: '100px' }}>
-      <Grid
-        container
-        spacing={1}
-        alignItems="center"
-        style={{ textAlign: 'center', alignItems: 'center' }}
-      >
+      <Grid container spacing={1} sx={{ textAlign: 'center', alignItems: 'center' }}>
         <Grid item xs={12}>
           <Typography variant="h4" pb={'2rem'}>
             Empower Change: Become a partner in our civic tech movement.

--- a/src/components/home/partners/Partners.jsx
+++ b/src/components/home/partners/Partners.jsx
@@ -2,8 +2,10 @@ import Typography from '@mui/material/Typography';
 import PrimaryPartner from './PrimaryPartner';
 import SecondaryPartners from './SecondaryPartners';
 import CallToAction from './CallToAction';
+// Other Library Imports
+import { PropTypes } from 'prop-types';
 
-const Partners = () => {
+const Partners = ({ showContactFormModal, setShowContactFormModal, handleContactForm }) => {
   return (
     <section>
       <Typography
@@ -18,8 +20,19 @@ const Partners = () => {
       </Typography>
       <PrimaryPartner />
       <SecondaryPartners />
-      <CallToAction />
+      <CallToAction
+        showContactFormModal={showContactFormModal}
+        setShowContactFormModal={setShowContactFormModal}
+        handleContactForm={handleContactForm}
+      />
     </section>
   );
 };
+
+Partners.propTypes = {
+  showContactFormModal: PropTypes.bool,
+  setShowContactFormModal: PropTypes.func,
+  handleContactForm: PropTypes.func
+};
+
 export default Partners;

--- a/src/components/home/partners/Partners.jsx
+++ b/src/components/home/partners/Partners.jsx
@@ -5,7 +5,7 @@ import CallToAction from './CallToAction';
 // Other Library Imports
 import { PropTypes } from 'prop-types';
 
-const Partners = ({ showContactFormModal, setShowContactFormModal, handleContactForm }) => {
+const Partners = (handleContactForm) => {
   return (
     <section>
       <Typography
@@ -20,18 +20,12 @@ const Partners = ({ showContactFormModal, setShowContactFormModal, handleContact
       </Typography>
       <PrimaryPartner />
       <SecondaryPartners />
-      <CallToAction
-        showContactFormModal={showContactFormModal}
-        setShowContactFormModal={setShowContactFormModal}
-        handleContactForm={handleContactForm}
-      />
+      <CallToAction handleContactForm={handleContactForm} />
     </section>
   );
 };
 
 Partners.propTypes = {
-  showContactFormModal: PropTypes.bool,
-  setShowContactFormModal: PropTypes.func,
   handleContactForm: PropTypes.func
 };
 

--- a/src/components/home/partners/Partners.jsx
+++ b/src/components/home/partners/Partners.jsx
@@ -2,10 +2,8 @@ import Typography from '@mui/material/Typography';
 import PrimaryPartner from './PrimaryPartner';
 import SecondaryPartners from './SecondaryPartners';
 import CallToAction from './CallToAction';
-// Other Library Imports
-import { PropTypes } from 'prop-types';
 
-const Partners = (handleContactForm) => {
+const Partners = () => {
   return (
     <section>
       <Typography
@@ -20,13 +18,9 @@ const Partners = (handleContactForm) => {
       </Typography>
       <PrimaryPartner />
       <SecondaryPartners />
-      <CallToAction handleContactForm={handleContactForm} />
+      <CallToAction />
     </section>
   );
-};
-
-Partners.propTypes = {
-  handleContactForm: PropTypes.func
 };
 
 export default Partners;

--- a/src/components/home/partners/SecondaryPartners.jsx
+++ b/src/components/home/partners/SecondaryPartners.jsx
@@ -1,13 +1,14 @@
+// Material UI Imports
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
-
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
-import { secondaryPartnerList } from './secondaryPartnerList';
-
+// Other Library Imports
 import { PropTypes } from 'prop-types';
+// Component Imports
+import { secondaryPartnerList } from './secondaryPartnerList';
 
 const secondaryPartnerProps = {
   index: PropTypes.number.isRequired,
@@ -15,7 +16,7 @@ const secondaryPartnerProps = {
   testimonial: PropTypes.string.isRequired,
   testimonialTwo: PropTypes.string,
   testimonialAuthorTwo: PropTypes.string,
-  testimonialAuthor: PropTypes.string.isRequired,
+  testimonialAuthor: PropTypes.string,
   partnerLogo: PropTypes.string.isRequired,
   website: PropTypes.string.isRequired
 };

--- a/src/components/home/partners/secondaryPartnerList.js
+++ b/src/components/home/partners/secondaryPartnerList.js
@@ -22,7 +22,6 @@ export const secondaryPartnerList = [
     company: 'Epicodus',
     testimonial:
       'Lorem ipsum dolor sit amet consectetur adipisicing elit. Ullam, quaerat saepe possimus ex dolor deleniti excepturi alias, est in tempore similique, inventore doloribus voluptatibus voluptate. Reiciendis minima nihil et dicta.',
-    testimonialAuthor: '- someone important there',
     partnerLogo: '/assets/epicodusLogo.png',
     website: 'https://www.epicodus.com/'
   }

--- a/src/components/projects/projectsList.jsx
+++ b/src/components/projects/projectsList.jsx
@@ -46,7 +46,7 @@ const projectsList = [
         icon: <FaEarthAmericas size={45} />
       }
     ],
-    techStack: 'SOLID, React, Vite, JSDocs, MUI, NPM, ES Lint'
+    techStack: 'SOLID, React, Vite, JSDocs, MUI, NPM, ESLint'
   },
   {
     index: 3,
@@ -54,7 +54,7 @@ const projectsList = [
     description:
       'Code PDX itself is a project that requires constant upkeep and volunteers to maintain. This ranges from project management, assisting with organizing events, or even updating this website! We are constantly improving to better help our community.',
     logo: '/assets/rose_logo.png',
-    techStack: 'SOLID, React, Vite, JSDocs, MUI, NPM, ES Lint'
+    techStack: 'SOLID, React, Vite, JSDocs, MUI, NPM, ESLint'
   }
 ];
 

--- a/src/components/projects/projectsList.jsx
+++ b/src/components/projects/projectsList.jsx
@@ -1,3 +1,4 @@
+// React Icons Imports
 import { FaDiscord, FaEarthAmericas, FaGithub } from 'react-icons/fa6';
 
 const projectsList = [

--- a/src/components/volunteer/VolunteerSteps.jsx
+++ b/src/components/volunteer/VolunteerSteps.jsx
@@ -7,7 +7,7 @@ import { useMediaQuery, useTheme } from '@mui/material';
 // React Vertical Timeline Imports
 import { VerticalTimeline, VerticalTimelineElement } from 'react-vertical-timeline-component';
 import 'react-vertical-timeline-component/style.min.css';
-// Custom Imports
+// Component Imports
 import volunteerStepsData from './volunteerStepsData';
 
 const getBackgroundStyle = (isSingleColumn, index) => {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -27,12 +27,25 @@ const Home = () => {
       />
       <Container maxWidth="xl">
         <About />
-        <VolunteerBrief />
+        <VolunteerBrief
+          showContactFormModal={showContactFormModal}
+          setShowContactFormModal={setShowContactFormModal}
+          handleContactForm={handleContactForm}
+        />
         <Events />
         <ProjectsBrief />
-        <Partners />
+        <Partners
+          showContactFormModal={showContactFormModal}
+          setShowContactFormModal={setShowContactFormModal}
+          handleContactForm={handleContactForm}
+        />
       </Container>
-      <ContactFormModal onClick={handleContactForm} />
+      <button onClick={handleContactForm}>Click me</button>
+      <ContactFormModal
+        showContactFormModal={showContactFormModal}
+        setShowContactFormModal={setShowContactFormModal}
+        handleContactForm={handleContactForm}
+      />
     </>
   );
 };

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,3 +1,5 @@
+// React Imports
+import { useState } from 'react';
 // Material UI Imports
 import { Container } from '@mui/material';
 // Component Imports
@@ -7,8 +9,15 @@ import VolunteerBrief from '../components/home/VolunteerBrief';
 import Events from '../components/home/Events';
 import ProjectsBrief from '../components/home/ProjectsBrief';
 import Partners from '../components/home/partners/Partners';
+import ContactFormModal from '../components/global/ContactFormModal';
 
 const Home = () => {
+  const [showContactFormModal, setShowContactFormModal] = useState(false);
+
+  const handleContactForm = () => {
+    setShowContactFormModal(!showContactFormModal);
+  };
+
   return (
     <>
       <Hero
@@ -23,6 +32,7 @@ const Home = () => {
         <ProjectsBrief />
         <Partners />
       </Container>
+      <ContactFormModal onClick={handleContactForm} />
     </>
   );
 };

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,3 @@
-// React Imports
-import { useState } from 'react';
 // Material UI Imports
 import { Container } from '@mui/material';
 // Component Imports
@@ -9,15 +7,8 @@ import VolunteerBrief from '../components/home/VolunteerBrief';
 import Events from '../components/home/Events';
 import ProjectsBrief from '../components/home/ProjectsBrief';
 import Partners from '../components/home/partners/Partners';
-import ContactFormModal from '../components/global/ContactFormModal';
 
 const Home = () => {
-  const [showContactFormModal, setShowContactFormModal] = useState(false);
-
-  const handleContactForm = () => {
-    setShowContactFormModal(!showContactFormModal);
-  };
-
   return (
     <>
       <Hero
@@ -27,25 +18,11 @@ const Home = () => {
       />
       <Container maxWidth="xl">
         <About />
-        <VolunteerBrief
-          showContactFormModal={showContactFormModal}
-          setShowContactFormModal={setShowContactFormModal}
-          handleContactForm={handleContactForm}
-        />
+        <VolunteerBrief />
         <Events />
         <ProjectsBrief />
-        <Partners
-          showContactFormModal={showContactFormModal}
-          setShowContactFormModal={setShowContactFormModal}
-          handleContactForm={handleContactForm}
-        />
+        <Partners />
       </Container>
-      <button onClick={handleContactForm}>Click me</button>
-      <ContactFormModal
-        showContactFormModal={showContactFormModal}
-        setShowContactFormModal={setShowContactFormModal}
-        handleContactForm={handleContactForm}
-      />
     </>
   );
 };

--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -10,7 +10,7 @@ import Grid from '@mui/material/Grid';
 import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-// Custom Imports
+// Component Imports
 import Hero from '../components/global/Hero/Hero';
 import projectsList from '../components/projects/projectsList';
 


### PR DESCRIPTION
## This PR:

Resolves #54

Adds contact form modal to the `Volunteer` and `Contact Us` buttons in `VolunteerBrief.jsx` and `CallToAction.jsx`, respectively.

Uses the `emailjs` dependency that routes messages to a test email account. 

I applied minimal styling, focusing first on setting up functionality.

Also removed `Contact Us` button from the main page hero, as it was related. So this PR could potentially close #58 (if that's all the issue requires).

---

## Screenshots (if applicable):

<img width="1060" alt="2023-11-17" src="https://github.com/codeforpdx/codepdx_website/assets/83156697/7c249b72-d93a-4d26-b6d1-b312d16df8e7">

---

## Future Steps/PRs Needed to Finish This Work (optional):

- Determine modal styling
- Further test `emailjs` and determine whether that is what we ultimately want to go with
- Decide all the places/buttons where we want the modal to be used
- Maybe make a "volunteer" version of the modal, perhaps changing just the title