### PR TITLE
107 enhancement secondary partners layout updates

### DIFF
--- a/src/components/home/partners/SecondaryPartners.jsx
+++ b/src/components/home/partners/SecondaryPartners.jsx
@@ -28,8 +28,7 @@ const partnerGridStyle = {
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
-  flexDirection: 'column',
-  pt: '20px'
+  flexDirection: 'column'
 };
 
 const LargeScreenComponent = ({
@@ -56,11 +55,20 @@ const LargeScreenComponent = ({
         borderRadius: '30px',
         minHeight: '450px',
         marginBottom: '100px',
-        flexDirection: 'row'
+        flexDirection: 'row',
+        pt: '5%'
       }}
       key={company}
     >
-      <Grid item {...partnerGridStyle} md={5} order={logoOrder}>
+      <Grid
+        item
+        {...partnerGridStyle}
+        md={5}
+        order={logoOrder}
+        sx={{
+          justifyContent: 'flex-start'
+        }}
+      >
         <a href={website} target="_blank" rel="noopener noreferrer">
           <Box
             component={'img'}
@@ -72,7 +80,7 @@ const LargeScreenComponent = ({
         </a>
       </Grid>
       <Grid item {...partnerGridStyle} md={7} order={contentOrder}>
-        <Typography variant="body1" p={'5% 10% 3% 10%'}>
+        <Typography variant="body1" p={'0% 10% 3% 10%'}>
           {testimonial}
         </Typography>
         {testimonialAuthor && (

--- a/src/components/home/partners/SecondaryPartners.jsx
+++ b/src/components/home/partners/SecondaryPartners.jsx
@@ -75,19 +75,21 @@ const LargeScreenComponent = ({
         <Typography variant="body1" p={'5% 10% 3% 10%'}>
           {testimonial}
         </Typography>
-        <Typography variant="caption" sx={{ fontWeight: 'bold' }} p={'0 0 0 0'}>
-          {testimonialAuthor}
-        </Typography>
-        {testimonialTwo ? (
+        {testimonialAuthor && (
+          <Typography variant="caption" sx={{ fontWeight: 'bold' }} p={'0 0 0 0'}>
+            {testimonialAuthor}
+          </Typography>
+        )}
+        {testimonialTwo && (
           <Typography variant="body1" display={'flex'} p={'5% 10% 3% 10%'}>
             {testimonialTwo}
           </Typography>
-        ) : null}
-        {testimonialAuthorTwo ? (
+        )}
+        {testimonialAuthorTwo && (
           <Typography variant="caption" sx={{ fontWeight: 'bold' }} pb={'10%'}>
             {testimonialAuthorTwo}
           </Typography>
-        ) : null}
+        )}
       </Grid>
     </Grid>
   );

--- a/src/components/home/partners/SecondaryPartners.jsx
+++ b/src/components/home/partners/SecondaryPartners.jsx
@@ -60,27 +60,26 @@ const LargeScreenComponent = ({
       }}
       key={company}
     >
-      <Grid item md={6} {...partnerGridStyle} order={logoOrder}>
+      <Grid item {...partnerGridStyle} md={5} order={logoOrder}>
         <a href={website} target="_blank" rel="noopener noreferrer">
           <Box
             component={'img'}
             alt={`${company} logo`}
             aria-label={`${company} logo`}
             src={partnerLogo}
-            mb={'150px'}
             width={'250px'}
           ></Box>
         </a>
       </Grid>
-      <Grid item pl={'6%'} {...partnerGridStyle} order={contentOrder}>
-        <Typography variant="body1" p={'5% 15% 3% 0'}>
+      <Grid item {...partnerGridStyle} md={7} order={contentOrder}>
+        <Typography variant="body1" p={'5% 10% 3% 10%'}>
           {testimonial}
         </Typography>
-        <Typography variant="caption" sx={{ fontWeight: 'bold' }} p={'0 0 5% 0'}>
+        <Typography variant="caption" sx={{ fontWeight: 'bold' }} p={'0 0 0 0'}>
           {testimonialAuthor}
         </Typography>
         {testimonialTwo ? (
-          <Typography variant="body1" display={'flex'} p={'3% 15% 3% 0'}>
+          <Typography variant="body1" display={'flex'} p={'5% 10% 3% 10%'}>
             {testimonialTwo}
           </Typography>
         ) : null}


### PR DESCRIPTION
## This PR:

Resolves #107

Changes for desktop version of `SecondaryPartners` component only

- Changed the grid layout to something closer to 60-40 (text-box to logo-box)
- Cards still appear to be scaling correctly based on the largest card (ORDSN)
- Fixed a small issue that we rendering an empty `<span>` if there was no `testimonialAuthor` prop
   - Changed the other conditional renders to use the `&&` short-circuit convention for consistency
- Design changes (based on my own opinion):
   - Changed some of the padding and alignment of the `SecondaryPartners` component
   - Centered the logo and text vertically; I think this makes the cards look better, but I can easily revert this if you guys like it better with some offset

---

## Screenshots (if applicable):

Here's what it looks like with these changes
![Screen Shot 2024-02-02 at 3 55 57 PM](https://github.com/codeforpdx/codepdx_website/assets/3335277/80ab9395-af85-42e6-a132-5c787976dde8)


---

## Future Steps/PRs Needed to Finish This Work (optional):

N/A