### PR TITLE
Events section style update

### DIFF
--- a/src/components/home/Events.jsx
+++ b/src/components/home/Events.jsx
@@ -6,14 +6,43 @@ import Link from '@mui/material/Link';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 
+const mobileStyle = {
+  position: 'relative',
+  paddingBottom: '100%', // larger for mobile
+  height: 0,
+  overflow: 'hidden'
+};
+
+const desktopStyle = {
+  position: 'relative',
+  paddingBottom: '75%', // smaller for desktop
+  height: 0,
+  overflow: 'hidden'
+};
 const leftSidePaperStyles = {
   elevation: 3,
   sx: {
-    mr: '30%',
+    mr: { xs: '0%', md: '30%' },
     mb: '40px',
     borderRadius: '20px',
-    background: 'rgba(217, 217, 217, 0.4)'
+    background: 'rgba(217, 217, 217, 0.4)',
+    width: { xs: '100%', md: 'auto' }
   }
+};
+const rightSidePaperStyles = {
+  elevation: 3,
+  sx: {
+    ml: { xs: '0%', md: '20%' },
+    mb: '40px',
+    mr: { xs: '0%', md: '10%' },
+    borderRadius: '20px',
+    background: 'rgba(217, 217, 217, 0.4)',
+    width: { xs: '100%', md: 'auto' }
+  }
+};
+
+const responsiveTextAlign = {
+  textAlign: { xs: 'center', md: 'left' }
 };
 
 const DiscordLink = () => {
@@ -60,11 +89,19 @@ const Events = () => {
     <Container maxWidth={false} as="section" id="events">
       <Grid pb={'40px'} container spacing={3} alignItems={'center'}>
         <Grid item xs={12} md={6}>
-          <Typography component="h2" pb={'40px'} variant="h3" align="center" gutterBottom>
+          <Typography
+            component="h2"
+            pb={'40px'}
+            variant="h3"
+            gutterBottom
+            sx={{
+              textAlign: { xs: 'center', md: 'left' }
+            }}
+          >
             Upcoming Events
           </Typography>
           <Paper {...leftSidePaperStyles}>
-            <Typography p={2}>
+            <Typography p={2} sx={responsiveTextAlign}>
               CODE PDX meets up in-person twice a month at <GrayboxLink /> in Portland. Once for a
               project demo night and onboarding event and again for in person work session at a
               bi-weekly cadence. We also occasionally do non working social meetups. Event times and
@@ -72,17 +109,8 @@ const Events = () => {
               the events section.
             </Typography>
           </Paper>
-          <Paper
-            elevation={3}
-            sx={{
-              ml: '20%',
-              mb: '40px',
-              mr: '10%',
-              borderRadius: '20px',
-              background: 'rgba(217, 217, 217, 0.4)'
-            }}
-          >
-            <Typography p={2}>
+          <Paper {...rightSidePaperStyles}>
+            <Typography p={2} sx={responsiveTextAlign}>
               Individual projects meet online weekly in Google meet with schedules being determined
               per group. Meeting links are found in the events on <DiscordLink />. Additionally
               there is a biweekly in person work session that all project groups can attend.
@@ -91,26 +119,39 @@ const Events = () => {
           <Paper {...leftSidePaperStyles}></Paper>
         </Grid>
         <Grid item xs={12} md={6}>
-          <Typography variant="h3" align="center">
+          <Typography
+            variant="h3"
+            align="center"
+            gutterBottom
+            sx={{
+              textAlign: 'center',
+              mb: 8 // Adjust this value for more or less space
+            }}
+          >
             CODE PDX Event Calendar
           </Typography>
-          <Container
-            maxWidth={'100%'}
-            sx={{
-              overflow: 'hidden',
-              mt: '50px'
+          <div
+            style={{
+              position: 'relative',
+              paddingBottom: '75%',
+              paddingTop: '15%',
+              height: 0,
+              overflow: 'hidden'
             }}
           >
             <CardMedia
               component="iframe"
               src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23ffffff&ctz=America%2FLos_Angeles&showNav=1&showTitle=0&showDate=1&showPrint=0&showTabs=0&src=YWU5NmQxZWU1ZGViNDM1MGEzMWE0OTAzMjExMjVmZDIxYTA4NDVlOWVlOTIxNTgxY2UyN2I5MjVkNWQ3MDdjNUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&src=ZW4udXNhI2hvbGlkYXlAZ3JvdXAudi5jYWxlbmRhci5nb29nbGUuY29t&color=%23A79B8E&color=%230B8043"
               sx={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
                 width: '100%',
-                height: { xs: '300px', md: '550px' },
+                height: '100%',
                 border: 'none'
               }}
-            ></CardMedia>
-          </Container>
+            />
+          </div>
         </Grid>
       </Grid>
     </Container>
@@ -118,3 +159,4 @@ const Events = () => {
 };
 
 export default Events;
+

--- a/src/components/home/Events.jsx
+++ b/src/components/home/Events.jsx
@@ -6,19 +6,7 @@ import Link from '@mui/material/Link';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 
-const mobileStyle = {
-  position: 'relative',
-  paddingBottom: '100%', 
-  height: 0,
-  overflow: 'hidden'
-};
 
-const desktopStyle = {
-  position: 'relative',
-  paddingBottom: '75%', 
-  height: 0,
-  overflow: 'hidden'
-};
 const leftSidePaperStyles = {
   elevation: 3,
   sx: {
@@ -116,7 +104,6 @@ const Events = () => {
               there is a biweekly in person work session that all project groups can attend.
             </Typography>
           </Paper>
-          <Paper {...leftSidePaperStyles}></Paper>
         </Grid>
         <Grid item xs={12} md={6}>
           <Typography

--- a/src/components/home/Events.jsx
+++ b/src/components/home/Events.jsx
@@ -8,14 +8,14 @@ import Typography from '@mui/material/Typography';
 
 const mobileStyle = {
   position: 'relative',
-  paddingBottom: '100%', // larger for mobile
+  paddingBottom: '100%', 
   height: 0,
   overflow: 'hidden'
 };
 
 const desktopStyle = {
   position: 'relative',
-  paddingBottom: '75%', // smaller for desktop
+  paddingBottom: '75%', 
   height: 0,
   overflow: 'hidden'
 };
@@ -125,7 +125,7 @@ const Events = () => {
             gutterBottom
             sx={{
               textAlign: 'center',
-              mb: 8 // Adjust this value for more or less space
+              mb: 8 
             }}
           >
             CODE PDX Event Calendar


### PR DESCRIPTION
## This PR:

Resolves #63 

---


## Future Steps/PRs Needed to Finish This Work (optional):  I made the text centered on mobile devices for the events section as described in the issue, but I noticed the text is not centered on mobile devices on other sections later in the page. If we like it, then its all good, but if we'd like them also changed, let me know, and I can quickly apply those changes as well.

