### PR TITLE
Updating volunteer page wording

### DIFF
--- a/src/components/volunteer/volunteerStepsData.jsx
+++ b/src/components/volunteer/volunteerStepsData.jsx
@@ -91,12 +91,12 @@ const volunteerStepsData = [
       {
         preText:
           'After seeing what we are up to, reach out to team members of a project to connect & let them know how you would like to contribute. You can find active members by seeing who recently contributed to a repository or the recent discord chat history of a project.',
-          numbered: true
+        numbered: true
       },
       {
         preText:
           "The GitHub repository is a good place to see what's active within CODE PDX and contains a writeup of our contribution guidelines that we follow to standardize our workflow.",
-          numbered: true
+        numbered: true
       }
     ]
   },
@@ -107,7 +107,7 @@ const volunteerStepsData = [
       {
         preText:
           'Find your first issue to work on from the GitHub repo of the project of your choice. Check out our ',
-        link: 'https://github.com/codeforpdx',
+        link: 'https://github.com/codeforpdx/PASS/wiki/Development#contribution-guidelines',
         linkText: 'Wiki',
         postText: ' for guidance on picking your first issue.',
         numbered: true

--- a/src/components/volunteer/volunteerStepsData.jsx
+++ b/src/components/volunteer/volunteerStepsData.jsx
@@ -40,13 +40,6 @@ const volunteerStepsData = [
         linkText: 'ADA Compliance Guide',
         postText: ', all CODE PDX projects are inclusive by design.',
         numbered: true
-      },
-      {
-        preText: 'Join a project demo night & onboarding session listed on ',
-        link: 'https://www.meetup.com/code-for-pdx/',
-        linkText: 'Meetup',
-        postText: '.',
-        numbered: true
       }
     ]
   },
@@ -136,12 +129,16 @@ const volunteerStepsData = [
         preText: '- All of these steps can be completed remotely or at an in-person event.'
       },
       {
-        preText:
-          '- We invite people to contribute to CODE PDX regardless of skill set or skill level.'
+        preText: '- Join a project demo night & onboarding session listed on ',
+        link: 'https://www.meetup.com/code-for-pdx/',
+        linkText: 'Meetup',
+        postText: '.'
       },
       {
-        preText:
-          '- When in doubt, proactively reach out in the Discord text channels. They are frequently checked by members and will likely yield a swift response.'
+        preText: '- People of all skill sets and skill levels are welcome at CODE PDX.'
+      },
+      {
+        preText: '- When in doubt, reach out! Our Discord channels are active and open.'
       }
     ]
   }


### PR DESCRIPTION
## This PR:

Resolves #120 

Moved text from `Self-Onboarding & Initial Contact` to `Additional Onboarding Info`

---

## Screenshots (if applicable):

<img width="587" alt="Capture" src="https://github.com/codeforpdx/codepdx_website/assets/83156697/a28e3939-9051-4148-b989-21b5baf6deb1">

---

## Future Steps/PRs Needed to Finish This Work (optional):

Also changed the wording of a couple of lines. I felt that messaging us on Discord "will likely yield a swift response" might come off as weirdly noncommittal. As though we aren't really sure how active or responsive we are. Can be changed back.