### PR TITLE
Issue 133/ADA compliance guide link

### DIFF
--- a/src/components/volunteer/volunteerStepsData.jsx
+++ b/src/components/volunteer/volunteerStepsData.jsx
@@ -36,7 +36,7 @@ const volunteerStepsData = [
       },
       {
         preText: 'Read the ',
-        link: 'https://github.com/codeforpdx',
+        link: 'https://www.ada.gov/resources/web-guidance',
         linkText: 'ADA Compliance Guide',
         postText: ', all CODE PDX projects are inclusive by design.',
         numbered: true


### PR DESCRIPTION
This commit updates the link for "ADA Compliance Guide" to point to the [ADA compliance guide](https://www.ada.gov/resources/web-guidance) rather than to the github link for this website.

Tested by running the dev instance locally and checking the link is updated.

## This PR:

Resolves #113 
