### PR TITLE
Fix alignment for primary and secondary partners

### DIFF
--- a/src/components/home/partners/PrimaryPartner.jsx
+++ b/src/components/home/partners/PrimaryPartner.jsx
@@ -57,7 +57,7 @@ const PrimaryPartner = () => {
       sx={{
         mb: '100px',
         borderRadius: '30px',
-        paddingTop: theme.palette.mode === 'dark' ? '10px' : '0px',
+        paddingTop: theme.palette.mode === 'dark' ? '50px' : '0px',
         background:
           theme.palette.mode === 'dark'
             ? `${theme.palette.primary.cardFill}`

--- a/src/components/home/partners/SecondaryPartners.jsx
+++ b/src/components/home/partners/SecondaryPartners.jsx
@@ -94,7 +94,6 @@ const LargeScreenComponent = ({
               alt={`${company} logo`}
               aria-label={`${company} logo`}
               src={partnerLogo}
-              mb={theme.palette.mode === 'dark' ? 0 : '150px'}
               width={'250px'}
             ></Box>
           </a>


### PR DESCRIPTION
## This PR:

Resolves #145

- Increases top padding for primary partner logo
- Removes bottom margin for secondary partners' logos

---

## Screenshots (if applicable):

Primary Partner Logo (once #143 is merged):
<img width="970" alt="Screenshot 2024-11-20 at 4 12 13 PM" src="https://github.com/user-attachments/assets/5c45eaf8-b907-436e-be09-dc52b8369799">

Secondary Partner Logo:
<img width="954" alt="Screenshot 2024-11-20 at 4 10 45 PM" src="https://github.com/user-attachments/assets/aee0a733-ad20-49c2-bd29-46279c453f23">

---

## Future Steps/PRs Needed to Finish This Work (optional):

Add any other steps/PRs that may be needed to continue this work if this PR is just a step in the right direction.
