### PR TITLE
Fixed dark mode toggle, body volunteer button for tab and select

### DIFF
--- a/src/components/global/Navbar.jsx
+++ b/src/components/global/Navbar.jsx
@@ -255,7 +255,7 @@ function NavBar({ darkMode, handleThemeChange }) {
         </Popover>
         {/* dark mode toggle */}
         <FormControlLabel
-          control={<DarkModeToggle checked={darkMode} onChange={handleThemeChange} />}
+          control={<DarkModeToggle checked={darkMode} onChange={handleThemeChange} onKeyDown={(event) => {event.key === 'Enter'? handleThemeChange() : ""}}/>}
         />
       </Toolbar>
     </AppBar>

--- a/src/components/home/VolunteerBrief.jsx
+++ b/src/components/home/VolunteerBrief.jsx
@@ -62,7 +62,8 @@ const volunteerGrid = [
 
 const VolunteerBrief = () => {
   const scrollToTop = () => {
-    window.scrollTo(0, 0);
+    // Allow page to change before scrolling to top
+    setTimeout(() => {window.scrollTo(0, 0)}, 400);
   };
   const theme = useTheme();
 
@@ -112,23 +113,17 @@ const VolunteerBrief = () => {
         </Grid>
         <Button
           variant="contained"
+          href="/volunteer"
+          aria-label="Volunteer for CODE PDX"
           color="senary"
           sx={{
             mt: { xs: '2em', md: '2em' },
             mb: { xs: '1em', md: 0 }
           }}
           onClick={scrollToTop}
+          onKeyDown={(event) => {event.key === 'Enter'? scrollToTop() : ""}}
         >
-          <Link
-            to="/volunteer"
-            style={{
-              textDecoration: 'none',
-              color: 'inherit'
-            }}
-            aria-label="Volunteer for CODE PDX"
-          >
-            Volunteer
-          </Link>
+          Volunteer
         </Button>
       </Card>
     </Stack>


### PR DESCRIPTION
## This PR:

Resolves #108

- Allows user to flip dark mode switch with 'enter' key
- Fixes volunteer button only scrolling to top of page, instead of switching pages, when tabbed to
- Volunteer button now only takes one tab, instead of two

---

## Screenshots (if applicable):

Dark mode switch:
https://github.com/user-attachments/assets/04e23f71-545e-481f-b716-6b5a50be4813

Volunteer button:
https://github.com/user-attachments/assets/61296305-67dc-43b8-bb6e-066ae91fcdef

---

## Future Steps/PRs Needed to Finish This Work (optional):

Add any other steps/PRs that may be needed to continue this work if this PR is just a step in the right direction.
